### PR TITLE
tmux: enable csi-u extended keys and document safe reload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,13 @@ Guidance for coding agents working in this repository.
   - git: `git status --short <path>` and/or `git diff -- <path>`
   - chezmoi: `chezmoi status <target>` and `chezmoi diff <target>`
 
+## tmux config reloads (non-destructive)
+
+- Apply tmux config updates with:
+  - `tmux source-file ~/.config/tmux/tmux.conf`
+- Do **not** use `tmux kill-server` unless explicitly requested by the user.
+- If a full tmux restart is required, explain impact first (all sessions terminate) and get confirmation.
+
 ## Chezmoi path mapping reminders
 
 - `home/dot_foo` -> `~/.foo`

--- a/home/dot_config/tmux/tmux.conf
+++ b/home/dot_config/tmux/tmux.conf
@@ -1,5 +1,7 @@
 # enable extended terminal features
-set -g default-terminal "wezterm"
+set -g default-terminal "xterm-ghostty"
+set -g extended-keys on
+set -g extended-keys-format csi-u
 set-option -gas terminal-overrides ",xterm*:Tc" # full color support
 set-option -gas terminal-overrides "*:Tc" # true color support
 set-option -gas terminal-overrides "*:RGB" # true color support


### PR DESCRIPTION
## Summary
- update tmux terminal setting to `xterm-ghostty`
- enable tmux extended keys and set `extended-keys-format` to `csi-u` for better modified key handling
- add AGENTS guidance to reload tmux config non-destructively via `tmux source-file` and avoid `tmux kill-server` unless explicitly requested

## Validation
- `chezmoi status ~/.config/tmux/tmux.conf`
- `chezmoi diff ~/.config/tmux/tmux.conf`
- `chezmoi apply --dry-run --verbose ~/.config/tmux/tmux.conf`

## Safety
- confirmed no secrets/runtime artifacts were committed
- scoped changes only to requested targets
