### PR TITLE
feat(fish): add jj-aware Tide VCS segment

### DIFF
--- a/home/dot_config/fish/conf.d/00-tide-vars.fish
+++ b/home/dot_config/fish/conf.d/00-tide-vars.fish
@@ -60,6 +60,19 @@ set -U tide_git_color_upstream 5FD700
 set -U tide_git_icon 
 set -U tide_git_truncation_length 24
 set -U tide_git_truncation_strategy
+set -U tide_vcs_bg_color 303030
+set -U tide_vcs_bookmark_icon 
+set -U tide_vcs_changeset_icon 
+set -U tide_vcs_color 5FD700
+set -U tide_vcs_color_bookmark D7AF00
+set -U tide_vcs_color_changeset 5FD700
+set -U tide_vcs_icon jj
+set -U tide_vcs_change_added_icon 
+set -U tide_vcs_change_copied_icon 
+set -U tide_vcs_change_modified_icon 
+set -U tide_vcs_change_removed_icon 
+set -U tide_vcs_change_renamed_icon 
+set -U tide_vcs_change_conflicted_icon 
 set -U tide_go_bg_color 303030
 set -U tide_go_color 00ACD7
 set -U tide_go_icon 
@@ -74,7 +87,7 @@ set -U tide_kubectl_bg_color 303030
 set -U tide_kubectl_color 326CE5
 set -U tide_kubectl_icon 󱃾
 set -U tide_left_prompt_frame_enabled true
-set -U tide_left_prompt_items os pwd git newline character
+set -U tide_left_prompt_items os pwd vcs newline character
 set -U tide_left_prompt_prefix 
 set -U tide_left_prompt_separator_diff_color 
 set -U tide_left_prompt_separator_same_color ╱

--- a/home/dot_config/fish/functions/_tide_item_vcs.fish
+++ b/home/dot_config/fish/functions/_tide_item_vcs.fish
@@ -1,0 +1,101 @@
+function _tide_item_vcs
+    if not command -sq jj
+        _tide_item_git
+        return
+    end
+
+    if not jj root --quiet >/dev/null 2>/dev/null
+        _tide_item_git
+        return
+    end
+
+    set -l change_id
+    jj log -r @ --no-graph -T 'change_id.shortest()' 2>/dev/null | read -l change_id
+    test -n "$change_id"; or return
+
+    set -l summary (jj diff --summary -r @ --ignore-working-copy 2>/dev/null)
+    set -l added (string match -r '^A ' $summary | count)
+    set -l modified (string match -r '^M ' $summary | count)
+    set -l removed (string match -r '^D ' $summary | count)
+    set -l renamed (string match -r '^R ' $summary | count)
+    set -l copied (string match -r '^C ' $summary | count)
+    set -l conflicts (jj resolve -r @ --list --ignore-working-copy 2>/dev/null | count)
+
+    set -g tide_vcs_bg_color $tide_git_bg_color
+    if test $conflicts -gt 0
+        set -g tide_vcs_bg_color $tide_git_bg_color_urgent
+    else if test (math "$added + $modified + $removed + $renamed + $copied") -gt 0
+        set -g tide_vcs_bg_color $tide_git_bg_color_unstable
+    end
+
+    set -l bookmark
+    set -l bookmark_color
+
+    # 1) Current changeset bookmark
+    set -l current_bookmarks (jj log -r @ --no-graph -T 'bookmarks' 2>/dev/null | string split ' ' | string match -rv '^$')
+    if test (count $current_bookmarks) -gt 0
+        set bookmark $current_bookmarks[1]
+        if contains -- main@origin $current_bookmarks
+            set bookmark main@origin
+        end
+        set bookmark_color $tide_git_color_branch
+    end
+
+    # 2) Closest parent bookmark (direct parent first, then nearest ancestor)
+    if test -z "$bookmark"
+        set -l parent_bookmarks (jj log -r '@-' --no-graph -T 'bookmarks' 2>/dev/null | string split ' ' | string match -rv '^$')
+        if test (count $parent_bookmarks) -eq 0
+            set parent_bookmarks (jj log -r 'heads(::@- & bookmarks())' --no-graph -n 1 -T 'bookmarks' 2>/dev/null | string split ' ' | string match -rv '^$')
+        end
+
+        if test (count $parent_bookmarks) -gt 0
+            set bookmark $parent_bookmarks[1]
+            if contains -- main@origin $parent_bookmarks
+                set bookmark main@origin
+            else
+                for b in $parent_bookmarks
+                    if string match -qr '@origin$' -- $b
+                        set bookmark $b
+                        break
+                    end
+                end
+            end
+            set bookmark_color $tide_git_color_staged
+        end
+    end
+
+    # 3) Closest child bookmark
+    if test -z "$bookmark"
+        set -l child_bookmarks (jj log -r 'roots(@+:: & bookmarks())' --no-graph -n 1 -T 'bookmarks' 2>/dev/null | string split ' ' | string match -rv '^$')
+        if test (count $child_bookmarks) -gt 0
+            set bookmark $child_bookmarks[1]
+            if contains -- main@origin $child_bookmarks
+                set bookmark main@origin
+            end
+            set bookmark_color $tide_git_color_untracked
+        end
+    end
+
+    _tide_print_item vcs $_tide_location_color$tide_vcs_icon' ' (set_color white; echo -ns $tide_vcs_changeset_icon' '$change_id
+        if test -n "$bookmark"
+            set_color $bookmark_color; echo -ns ' '$tide_vcs_bookmark_icon' '$bookmark
+        end
+        if test $added -gt 0
+            set_color $tide_git_color_staged; echo -ns ' '$tide_vcs_change_added_icon' '$added
+        end
+        if test $modified -gt 0
+            set_color $tide_git_color_dirty; echo -ns ' '$tide_vcs_change_modified_icon' '$modified
+        end
+        if test $removed -gt 0
+            set_color $tide_git_color_conflicted; echo -ns ' '$tide_vcs_change_removed_icon' '$removed
+        end
+        if test $renamed -gt 0
+            set_color $tide_git_color_upstream; echo -ns ' '$tide_vcs_change_renamed_icon' '$renamed
+        end
+        if test $copied -gt 0
+            set_color $tide_git_color_untracked; echo -ns ' '$tide_vcs_change_copied_icon' '$copied
+        end
+        if test $conflicts -gt 0
+            set_color $tide_git_color_conflicted; echo -ns ' '$tide_vcs_change_conflicted_icon' '$conflicts
+        end)
+end


### PR DESCRIPTION
## Summary
- add a custom Tide `vcs` segment for Jujutsu repositories
- hide Git segment in jj repos by replacing `git` with `vcs` in `tide_left_prompt_items`
- show shortest unique jj change id
- show nearest bookmark context with color semantics (current/parent/child)
- add octicon-based change counters (added/modified/removed/renamed/copied/conflicts), hidden when zero
- keep colors aligned with existing Tide git colors

## Validation
- `fish -n home/dot_config/fish/functions/_tide_item_vcs.fish`
- `fish -n home/dot_config/fish/conf.d/00-tide-vars.fish`
- manual prompt checks in jj and non-jj directories

## Notes
- This branch builds on existing fish/tide setup commits that are not on `master` yet.
